### PR TITLE
Sanitize next navigation paths

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -24,6 +24,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import Logo from '@/components/Logo'
 import { Mail, ArrowLeft } from 'lucide-react'
+import { normalizeNextPath } from '@/utils/url'
 
 const authSchema = z.object({
   email: z.string().email('Please enter a valid email address'),
@@ -63,7 +64,7 @@ const Auth: React.FC = () => {
   const onSubmit = async (data: AuthFormData) => {
     setIsLoading(true)
     try {
-      const next = searchParams.get('next') || '/app'
+      const next = normalizeNextPath(searchParams.get('next'))
       
       if (isSignUp) {
         const { error } = await signUpWithEmail(data.email, data.password)
@@ -134,7 +135,7 @@ const Auth: React.FC = () => {
   const onGoogleSignIn = async () => {
     setIsLoading(true)
     try {
-      const next = searchParams.get('next') || '/app'
+      const next = normalizeNextPath(searchParams.get('next'))
       const { error } = await signInWithGoogle(next)
       if (error) {
         toast({

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from '@/integrations/supabase/client'
+import { normalizeNextPath } from '@/utils/url'
 
 export default function AuthCallback() {
   const navigate = useNavigate()
@@ -9,7 +10,7 @@ export default function AuthCallback() {
     (async () => {
       try {
         const qs = new URLSearchParams(window.location.search)
-        const next = qs.get('next') || '/app'
+        const next = normalizeNextPath(qs.get('next'))
 
         // Handle both OAuth (PKCE) and magic-link/hash flows
         const { error } = await supabase.auth.exchangeCodeForSession(window.location.href)

--- a/src/utils/__tests__/url.spec.ts
+++ b/src/utils/__tests__/url.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeNextPath, NEXT_FALLBACK_PATH } from '@/utils/url'
+
+describe('normalizeNextPath', () => {
+  it('returns fallback for empty or missing values', () => {
+    expect(normalizeNextPath()).toBe(NEXT_FALLBACK_PATH)
+    expect(normalizeNextPath('')).toBe(NEXT_FALLBACK_PATH)
+    expect(normalizeNextPath('   ')).toBe(NEXT_FALLBACK_PATH)
+  })
+
+  it('allows safe same-origin paths', () => {
+    expect(normalizeNextPath('/app')).toBe('/app')
+    expect(normalizeNextPath('/#/dashboard')).toBe('/#/dashboard')
+    expect(normalizeNextPath('/app?foo=bar')).toBe('/app?foo=bar')
+    expect(normalizeNextPath('   /tests/123  ')).toBe('/tests/123')
+  })
+
+  it('rejects attempts to use full URLs or protocols', () => {
+    expect(normalizeNextPath('https://evil.com')).toBe(NEXT_FALLBACK_PATH)
+    expect(normalizeNextPath('http://evil.com')).toBe(NEXT_FALLBACK_PATH)
+    expect(normalizeNextPath('/javascript:alert(1)')).toBe(NEXT_FALLBACK_PATH)
+  })
+
+  it('rejects paths containing double slashes', () => {
+    expect(normalizeNextPath('//evil.com')).toBe(NEXT_FALLBACK_PATH)
+    expect(normalizeNextPath('/foo//bar')).toBe(NEXT_FALLBACK_PATH)
+    expect(normalizeNextPath('/app?next=//evil.com')).toBe(NEXT_FALLBACK_PATH)
+  })
+})

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,33 @@
+export const NEXT_FALLBACK_PATH = '/app'
+
+const PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:/
+
+export const normalizeNextPath = (value?: string | null): string => {
+  if (!value) {
+    return NEXT_FALLBACK_PATH
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed.startsWith('/')) {
+    return NEXT_FALLBACK_PATH
+  }
+
+  if (trimmed.startsWith('//')) {
+    return NEXT_FALLBACK_PATH
+  }
+
+  if (trimmed.includes('//')) {
+    return NEXT_FALLBACK_PATH
+  }
+
+  const withoutLeadingSlash = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed
+  if (PROTOCOL_PATTERN.test(withoutLeadingSlash)) {
+    return NEXT_FALLBACK_PATH
+  }
+
+  if (trimmed.includes('://')) {
+    return NEXT_FALLBACK_PATH
+  }
+
+  return trimmed || NEXT_FALLBACK_PATH
+}


### PR DESCRIPTION
## Summary
- add a shared `normalizeNextPath` helper to constrain next navigation targets to safe same-origin paths
- use the helper in the auth and callback pages before redirecting users
- add unit tests that cover safe, malicious, and malformed next values

## Testing
- npm run test:unit *(fails: requires Supabase credentials in test env)*
- npx vitest run src/utils/__tests__/url.spec.ts --reporter=dot


------
https://chatgpt.com/codex/tasks/task_e_68d713122244832a9b28af812c78c2e8